### PR TITLE
chore: update .gitignore to exclude logs, environment files, and editor artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ node_modules/
 
 # Miscellaneous
 .DS_Store
+.env
+.env.*
 .env.local
 .env.development.local
 .env.test.local
@@ -19,11 +21,22 @@ node_modules/
 temp/
 _trash/
 *.backup
+*~
+*.swp
+*.swo
+.history/
+uncommitted-*
+*secret*
+*key*
+.cache/
 
 # Logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+*.log
+test-results*.log
+logs/
 
 # Editor directories and files
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored ResourceManager and BuildingManager to use dependency injection
 - Updated App initialization to support both direct store and dependency injection
 - Improved type safety of manager classes with proper interfaces and type imports
+- Enhanced .gitignore to exclude logs, environment files, editor artifacts, and secrets
 
 ### Fixed
 - Fixed TypeError in GameLoop by adding support for flat resource structure in gameEndConditions.ts


### PR DESCRIPTION
## Summary
- Enhanced .gitignore to exclude logs, environment files, editor artifacts, and secrets
- Adds protection against committing environment variables, secrets, and keys
- Ignores unwanted logs, editor artifacts, and temporary files
- Updated CHANGELOG.md to reflect changes

## Test plan
- Verified that the .gitignore excludes logs, environment files, editor artifacts, and secrets
- Confirmed no sensitive data is being tracked in the repository

🤖 Generated with Claude Code