### PR TITLE
Fix: replace semantic PR action with custom implementation

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -3,7 +3,7 @@ name: PR Validation
 on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   validate-pr:
@@ -17,26 +17,21 @@ jobs:
         uses: actions/checkout@v4
         
       - name: Validate PR title
-        uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          types:
-            - feat
-            - fix
-            - docs
-            - style
-            - refactor
-            - perf
-            - test
-            - build
-            - ci
-            - chore
-            - revert
-          requireScope: false
-          subjectPattern: ^[A-Z].+$
-          subjectPatternError: |
-            The subject must begin with a capital letter and not end with a period.
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          
+          # Check if PR title follows conventional commit format
+          if ! [[ "$PR_TITLE" =~ ^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9-]+\))?: [A-Z].+ ]]; then
+            echo "::error::PR title must follow the pattern: type(scope): Subject"
+            echo "::error::Example: feat: Add user authentication"
+            echo "::error::Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert"
+            exit 1
+          fi
+          
+          echo "PR title is valid: $PR_TITLE"
+        shell: bash
             
       - name: Verify branch name
         run: |
@@ -45,6 +40,8 @@ jobs:
             echo "::error::Branch name doesn't follow the pattern: (feature|fix|docs|refactor|ci|chore|test)/[a-z0-9-]+"
             exit 1
           fi
+          
+          echo "Branch name is valid: $BRANCH_NAME"
         shell: bash
       
   check-changelog:
@@ -75,4 +72,6 @@ jobs:
             echo "::error::CHANGELOG.md was not updated. Please add an entry for your changes."
             exit 1
           fi
+          
+          echo "CHANGELOG.md has been updated"
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Simplified workflow with clearer division between local and remote responsibilities
 
 ### Fixed
-- Fixed YAML syntax issue in PR validation workflow
+- Fixed YAML syntax issue in PR validation workflow by replacing the third-party action with a custom implementation
 
 ## [0.5.0-4] - 2025-02-27
 


### PR DESCRIPTION
## Description
This PR fixes the persistent YAML syntax issue in the PR validation workflow by replacing the third-party semantic PR action with a custom implementation using bash script.

## Problem
The GitHub Actions workflow was consistently failing with an error about invalid YAML syntax, even after attempting to rewrite the file. The error was:

\

## Solution
- Replaced the \ action with a custom bash implementation
- Implemented the same validation logic but using regular expressions directly in bash
- Updated the CHANGELOG.md with the fix

## Testing
- Verified the YAML syntax with a YAML validator