### PR TITLE
Fix: update PR validation workflow with compatible regex patterns

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -14,36 +14,31 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         
-      - name: Validate branch name
+      - name: Validate branch name and PR title
         run: |
+          # Get branch name
           BRANCH_NAME="${{ github.head_ref }}"
-          echo "Checking branch: $BRANCH_NAME"
+          echo "Branch: $BRANCH_NAME"
           
-          if [[ ! "$BRANCH_NAME" =~ ^(feature|fix|docs|refactor|ci|chore|test)/[a-z0-9-]+$ ]]; then
-            echo "::error::Branch name doesn't follow the pattern: (feature|fix|docs|refactor|ci|chore|test)/[a-z0-9-]+"
+          # Check branch name format
+          if ! echo "$BRANCH_NAME" | grep -E "^(feature|fix|docs|refactor|ci|chore|test)/[a-z0-9-]+" > /dev/null; then
+            echo "Error: Branch name doesn't follow the pattern: (feature|fix|docs|refactor|ci|chore|test)/name"
+            echo "Examples: feature/login-page, fix/auth-bug"
             exit 1
           fi
           
-          echo "Branch name is valid"
-  
-  check-title:
-    name: Check PR Title
-    runs-on: ubuntu-latest
-    
-    steps:
-      - name: Validate PR title format
-        run: |
+          # Get PR title
           PR_TITLE="${{ github.event.pull_request.title }}"
-          echo "Checking PR title: $PR_TITLE"
+          echo "PR title: $PR_TITLE"
           
-          # Check for conventional commit format
-          if ! [[ "$PR_TITLE" =~ ^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(:|\([a-z0-9-]+\):) ]]; then
-            echo "::error::PR title must follow the conventional commit format"
-            echo "::error::Examples: 'feat: Add user login' or 'fix(auth): Fix password reset'"
+          # Check PR title format (conventional commits)
+          if ! echo "$PR_TITLE" | grep -E "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\\([a-z0-9-]+\\))?: [A-Z]" > /dev/null; then
+            echo "Error: PR title must follow the conventional commit format"
+            echo "Examples: 'feat: Add user login' or 'fix(auth): Fix password reset'"
             exit 1
           fi
           
-          echo "PR title format is valid"
+          echo "Validation passed: Branch name and PR title are correctly formatted"
   
   check-changelog:
     name: Check CHANGELOG
@@ -57,18 +52,21 @@ jobs:
           
       - name: Check CHANGELOG.md update
         run: |
-          # Skip this check for specific PR types
+          # Get PR title for type detection
           PR_TITLE="${{ github.event.pull_request.title }}"
-          if [[ "$PR_TITLE" =~ ^(docs:|chore:|ci:|test:) ]]; then
+          echo "PR title: $PR_TITLE"
+          
+          # Skip this check for specific PR types
+          if echo "$PR_TITLE" | grep -E "^(docs|chore|ci|test):" > /dev/null; then
             echo "PR type doesn't require CHANGELOG update, skipping check"
             exit 0
           fi
           
           # Check if CHANGELOG.md was modified
-          git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep -q "CHANGELOG.md"
-          if [ $? -ne 0 ]; then
-            echo "::error::CHANGELOG.md was not updated. Please add an entry for your changes."
+          if ! git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep "CHANGELOG.md" > /dev/null; then
+            echo "Error: CHANGELOG.md was not updated"
+            echo "Please add an entry for your changes to the [Unreleased] section of CHANGELOG.md"
             exit 1
           fi
           
-          echo "CHANGELOG.md has been updated"
+          echo "CHANGELOG.md has been updated correctly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed YAML syntax issue in PR validation workflow by completely redesigning the workflow structure
 - Removed redundant changelog check workflow to prevent duplication
+- Fixed regex patterns in PR validation workflow to use more compatible syntax
 
 ## [0.5.0-4] - 2025-02-27
 


### PR DESCRIPTION
## Description
This PR fixes the PR validation workflow by replacing bash regex patterns with more compatible grep patterns.

## Problem
The workflow was failing with exit code 2, which indicates a regex compatibility issue in the bash scripts.

## Solution
- Replaced bash regex patterns with grep -E patterns
- Combined validation steps for clarity
- Improved error messages
- Added validation output messages
- Updated the CHANGELOG.md with the fix

## Testing
- Tested the grep patterns locally to ensure they match correctly