### PR TITLE
fix: update GitHub Actions workflow for auto-versioning

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,9 +41,8 @@
 
 ### Documentation and Quality
 - [ ] Documentation is updated as needed
-- [ ] CHANGELOG.md is updated with changes
-- [ ] For PRs to main: Changes are properly versioned using `./scripts/bump-version.sh X.Y.Z`
-- [ ] package.json version matches CHANGELOG.md version
+- [ ] CHANGELOG.md is updated with changes in the Unreleased section
+- [ ] PR has the appropriate version label (version:major, version:minor, version:patch, or version:patch_level)
 - [ ] No debug/console logs in production code
 - [ ] Branch is updated with main
 

--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -123,13 +123,17 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'version:patch') ||
       contains(github.event.pull_request.labels.*.name, 'version:patch_level'))
     
+    permissions:
+      contents: write
+      pull-requests: write
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           # Full git history needed for version bumping
           fetch-depth: 0
-          # Need token with write access to push version bump
+          # Use a personal access token with repo scope
           token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Setup Node.js
@@ -171,23 +175,20 @@ jobs:
           
           .github/workflows/scripts/auto-version.sh
         
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+      
       - name: Push version bump
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.event.pull_request.base.ref }}
+        run: |
+          git push origin HEAD:${{ github.event.pull_request.base.ref }}
       
       - name: Create Git tag
         run: |
           NEW_VERSION=$(node -e "console.log(require('./package.json').version)")
           git tag "v$NEW_VERSION"
-      
-      - name: Push Git tag
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.event.pull_request.base.ref }}
-          tags: true
+          git push origin "v$NEW_VERSION"
       
       - name: Comment on PR
         uses: actions/github-script@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed redundant changelog check workflow to prevent duplication
 - Fixed regex patterns in PR validation workflow to use more compatible syntax
 - Made PR title validation case-insensitive to accept both "fix:" and "Fix:" format
+- Fixed GitHub Actions workflow permission issue for auto-versioning
 
 ### Removed
 - Legacy example semantic-release configuration


### PR DESCRIPTION
## Summary
This PR fixes permission issues with the auto-versioning GitHub Action workflow.

## Changes
- Added proper permissions for GitHub Actions bot in auto-version.yml
- Replaced the github-push-action with direct git commands
- Updated PR template to mention version labels instead of manual versioning
- Added entry to CHANGELOG.md about fixing the permissions issue

## Testing
- Reviewed the workflow file against GitHub Actions documentation
- The version:patch PR should now auto-version properly

## Documentation
- Updated PR template to reflect current workflow
- Improved comments in auto-version.yml workflow