### PR TITLE
fix: update tests to handle tutorial state in store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Updated test files to handle tutorial state in Redux store
+- Fixed type issues in TutorialManager to use RootState instead of AppState
+- Resolved Redux store initialization in various test files
+
 ## [0.5.2] - 2025-02-27
 
 

--- a/src/managers/TutorialManager.ts
+++ b/src/managers/TutorialManager.ts
@@ -1,6 +1,6 @@
 import { Store } from '@reduxjs/toolkit';
 import { tutorialContent, contextualHelpContent } from '../data/tutorialContent';
-import { AppState } from '../state/store';
+import { RootState } from '../state/store';
 import { 
   completeTutorial, 
   setActiveTutorial, 
@@ -16,7 +16,7 @@ import { TutorialContextHelp, TutorialStep } from '../types/tutorial';
  */
 export class TutorialManager {
   private static instance: TutorialManager;
-  private store: Store | null = null;
+  private store: Store<RootState> | null = null;
 
   private constructor() {
     // Private constructor for singleton
@@ -35,7 +35,7 @@ export class TutorialManager {
   /**
    * Initialize the tutorial manager with the Redux store
    */
-  public initialize(store: Store): void {
+  public initialize(store: Store<RootState>): void {
     this.store = store;
     this.checkFirstTimeUser();
   }
@@ -46,7 +46,7 @@ export class TutorialManager {
   private checkFirstTimeUser(): void {
     if (!this.store) return;
 
-    const state = this.store.getState() as AppState;
+    const state = this.store.getState();
     const { firstTimeUser, tutorialsEnabled } = state.tutorial;
 
     if (firstTimeUser && tutorialsEnabled) {
@@ -70,13 +70,13 @@ export class TutorialManager {
   public completeCurrentStep(): void {
     if (!this.store) return;
     
-    const state = this.store.getState() as AppState;
+    const state = this.store.getState();
     const { currentStep } = state.tutorial;
     
     if (currentStep) {
       this.store.dispatch(completeTutorial(currentStep));
       
-      const tutorial = tutorialContent[currentStep];
+      const tutorial = tutorialContent[currentStep as TutorialStep];
       if (tutorial.nextStep) {
         this.store.dispatch(setCurrentStep(tutorial.nextStep));
       } else {
@@ -92,11 +92,11 @@ export class TutorialManager {
   public goToPreviousStep(): void {
     if (!this.store) return;
     
-    const state = this.store.getState() as AppState;
+    const state = this.store.getState();
     const { currentStep } = state.tutorial;
     
     if (currentStep) {
-      const tutorial = tutorialContent[currentStep];
+      const tutorial = tutorialContent[currentStep as TutorialStep];
       if (tutorial.previousStep) {
         this.store.dispatch(setCurrentStep(tutorial.previousStep));
       }
@@ -148,11 +148,11 @@ export class TutorialManager {
   public getCurrentTutorialContent() {
     if (!this.store) return null;
     
-    const state = this.store.getState() as AppState;
+    const state = this.store.getState();
     const { currentStep } = state.tutorial;
     
     if (currentStep) {
-      return tutorialContent[currentStep];
+      return tutorialContent[currentStep as TutorialStep];
     }
     
     return null;
@@ -164,7 +164,7 @@ export class TutorialManager {
   public isTutorialCompleted(tutorialId: string): boolean {
     if (!this.store) return false;
     
-    const state = this.store.getState() as AppState;
-    return state.tutorial.completedTutorials.includes(tutorialId);
+    const state = this.store.getState();
+    return state.tutorial.completed.includes(tutorialId);
   }
 }

--- a/src/systems/__tests__/gameLoop.test.ts
+++ b/src/systems/__tests__/gameLoop.test.ts
@@ -15,6 +15,7 @@ import structuresReducer from '../../state/structuresSlice';
 import eventsReducer from '../../state/eventsSlice';
 import tasksReducer from '../../state/tasksSlice';
 import progressionReducer from '../../redux/progressionSlice';
+import tutorialReducer from '../../state/tutorialSlice';
 import { resetSingleton } from '../../utils/testUtils';
 
 // Mock setInterval and clearInterval
@@ -54,6 +55,7 @@ const createTestStore = () => {
       events: eventsReducer,
       tasks: tasksReducer,
       progression: progressionReducer,
+      tutorial: tutorialReducer,
     },
   });
   


### PR DESCRIPTION
This PR fixes issues with tests after the addition of the tutorial feature:

1. Adds the tutorial reducer to the mock stores in:
   - eventManager.test.ts
   - gameLoop.test.ts
   - selectors.test.ts

2. Fixes type issues in TutorialManager.ts:
   - Updates AppState to RootState 
   - Adds proper generic type to Store interface
   - Fixes type safety by adding type assertions for TutorialStep
   - Updates property name from completedTutorials to completed

These changes ensure all tests can properly handle the tutorial state that was added to the Redux store.