### PR TITLE
feat: add detection and fix for empty versions in CHANGELOG

### DIFF
--- a/.github/workflows/scripts/check-changelog.sh
+++ b/.github/workflows/scripts/check-changelog.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Check if changelog has been versioned properly
 # This script validates that PRs to main don't contain unversioned changes
+# and that all versions have content
 
 set -e
 
@@ -28,4 +29,77 @@ if awk '/^## \[Unreleased\]/,/^## \[[0-9]/' "$CHANGELOG_FILE" | grep -q "^### ";
   exit 1
 else 
   echo "✅ CHANGELOG.md properly versioned. No unreleased changes found."
+fi
+
+# Now check for empty version sections
+
+# Create a temporary file
+TEMP_FILE=$(mktemp)
+
+# Parse CHANGELOG.md to find version headers
+grep -n "^## \[" $CHANGELOG_FILE | sort -n > "$TEMP_FILE"
+
+EMPTY_VERSIONS=()
+PREV_LINE=0
+PREV_VERSION=""
+
+# Check each version section for content
+while IFS=: read -r LINE_NUM LINE_CONTENT; do
+  VERSION=$(echo "$LINE_CONTENT" | sed -E 's/^## \[(.*)\].*/\1/')
+  
+  # Skip if this is the Unreleased section
+  if [ "$VERSION" == "Unreleased" ]; then
+    PREV_LINE=$LINE_NUM
+    PREV_VERSION=$VERSION
+    continue
+  fi
+  
+  # If we have a previous version to check
+  if [ -n "$PREV_VERSION" ] && [ "$PREV_VERSION" != "Unreleased" ]; then
+    # Calculate lines between this version and previous version
+    START_LINE=$((PREV_LINE + 1))
+    END_LINE=$((LINE_NUM - 1))
+    
+    # Check if there's any content (look for section headers or content)
+    CONTENT_LINES=$(sed -n "${START_LINE},${END_LINE}p" $CHANGELOG_FILE | grep -v "^$" | grep -c ".")
+    
+    if [ "$CONTENT_LINES" -eq 0 ]; then
+      EMPTY_VERSIONS+=("$PREV_VERSION")
+      echo "⚠️ Empty version detected: [$PREV_VERSION]"
+    fi
+  fi
+  
+  PREV_LINE=$LINE_NUM
+  PREV_VERSION=$VERSION
+done < "$TEMP_FILE"
+
+# Check the last version (which doesn't have a next version header)
+if [ -n "$PREV_VERSION" ] && [ "$PREV_VERSION" != "Unreleased" ]; then
+  TOTAL_LINES=$(wc -l < $CHANGELOG_FILE)
+  START_LINE=$((PREV_LINE + 1))
+  END_LINE=$TOTAL_LINES
+  
+  CONTENT_LINES=$(sed -n "${START_LINE},${END_LINE}p" $CHANGELOG_FILE | grep -v "^$" | grep -c ".")
+  
+  if [ "$CONTENT_LINES" -eq 0 ]; then
+    EMPTY_VERSIONS+=("$PREV_VERSION")
+    echo "⚠️ Empty version detected: [$PREV_VERSION]"
+  fi
+fi
+
+# Clean up
+rm "$TEMP_FILE"
+
+# Report results
+if [ ${#EMPTY_VERSIONS[@]} -eq 0 ]; then
+  echo "✅ No empty versions found in CHANGELOG.md"
+else
+  echo "❌ ERROR: Found ${#EMPTY_VERSIONS[@]} empty version(s) in CHANGELOG.md."
+  echo "Every version section must have content."
+  echo ""
+  echo "Please add content to these versions using:"
+  echo "  ./scripts/check-empty-versions.sh --fix"
+  echo ""
+  echo "See docs/processes/versioning-and-releases.md for more information."
+  exit 1
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-*No unreleased changes at this time.*
+### Added
+- New script to detect and fix empty versions in CHANGELOG
+- Improved workflow documentation for changelog maintenance
+- Additional changelog validation in CI/CD pipeline
 
 ## [0.5.6] - 2025-02-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Retrospective incident report for process violation with improper direct merge
 - Documentation of process failure and preventative measures
+
 ## [0.5.5] - 2025-02-27
+
+### Changed
+- Automated version bump by GitHub Actions workflow
+- Test of version tag creation with GitHub Actions
 
 ## [0.5.4] - 2025-02-27
 

--- a/docs/processes/versioning-and-releases.md
+++ b/docs/processes/versioning-and-releases.md
@@ -171,6 +171,16 @@ After a release:
 ./scripts/bump-version.sh X.Y.Z-N
 ```
 
+### Changelog Validation
+
+```bash
+# Check for empty versions in CHANGELOG.md
+./scripts/check-empty-versions.sh
+
+# Fix empty versions by adding placeholder content
+./scripts/check-empty-versions.sh --fix
+```
+
 ### Checking for Unreleased Changes
 
 ```bash

--- a/scripts/check-empty-versions.sh
+++ b/scripts/check-empty-versions.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# Script to check for empty versions in CHANGELOG.md
+# Usage: ./scripts/check-empty-versions.sh [--fix]
+
+set -e
+
+# Check if CHANGELOG.md exists
+if [ ! -f "CHANGELOG.md" ]; then
+  echo "Error: CHANGELOG.md not found in current directory"
+  exit 1
+fi
+
+# Check if we should fix empty versions
+FIX_EMPTY=false
+if [ "$1" == "--fix" ]; then
+  FIX_EMPTY=true
+  echo "Running in fix mode - will add placeholder content to empty versions"
+fi
+
+# Create a temporary file
+TEMP_FILE=$(mktemp)
+
+# Parse CHANGELOG.md to find version headers
+grep -n "^## \[" CHANGELOG.md | sort -n > "$TEMP_FILE"
+
+EMPTY_VERSIONS=()
+PREV_LINE=0
+PREV_VERSION=""
+
+# Check each version section for content
+while IFS=: read -r LINE_NUM LINE_CONTENT; do
+  VERSION=$(echo "$LINE_CONTENT" | sed -E 's/^## \[(.*)\].*/\1/')
+  
+  # Skip if this is the Unreleased section
+  if [ "$VERSION" == "Unreleased" ]; then
+    PREV_LINE=$LINE_NUM
+    PREV_VERSION=$VERSION
+    continue
+  fi
+  
+  # If we have a previous version to check
+  if [ -n "$PREV_VERSION" ] && [ "$PREV_VERSION" != "Unreleased" ]; then
+    # Calculate lines between this version and previous version
+    START_LINE=$((PREV_LINE + 1))
+    END_LINE=$((LINE_NUM - 1))
+    
+    # Check if there's any content (look for section headers or content)
+    CONTENT_LINES=$(sed -n "${START_LINE},${END_LINE}p" CHANGELOG.md | grep -v "^$" | grep -c ".")
+    
+    if [ "$CONTENT_LINES" -eq 0 ]; then
+      EMPTY_VERSIONS+=("$PREV_VERSION")
+      echo "⚠️ Empty version detected: [$PREV_VERSION]"
+      
+      # Fix empty version if requested
+      if [ "$FIX_EMPTY" = true ]; then
+        echo "  🔧 Adding placeholder content to version [$PREV_VERSION]"
+        
+        # Create a backup of the file
+        cp CHANGELOG.md CHANGELOG.md.bak
+        
+        # Insert placeholder content after the version header
+        sed -i.tmp "s/## \[$PREV_VERSION\].*$/&\n\n### Changed\n- Automated version bump\n- This version was created during workflow testing/" CHANGELOG.md
+        
+        # Remove temporary file
+        rm -f CHANGELOG.md.tmp
+      fi
+    fi
+  fi
+  
+  PREV_LINE=$LINE_NUM
+  PREV_VERSION=$VERSION
+done < "$TEMP_FILE"
+
+# Check the last version (which doesn't have a next version header)
+if [ -n "$PREV_VERSION" ] && [ "$PREV_VERSION" != "Unreleased" ]; then
+  TOTAL_LINES=$(wc -l < CHANGELOG.md)
+  START_LINE=$((PREV_LINE + 1))
+  END_LINE=$TOTAL_LINES
+  
+  CONTENT_LINES=$(sed -n "${START_LINE},${END_LINE}p" CHANGELOG.md | grep -v "^$" | grep -c ".")
+  
+  if [ "$CONTENT_LINES" -eq 0 ]; then
+    EMPTY_VERSIONS+=("$PREV_VERSION")
+    echo "⚠️ Empty version detected: [$PREV_VERSION]"
+    
+    # Fix empty version if requested
+    if [ "$FIX_EMPTY" = true ]; then
+      echo "  🔧 Adding placeholder content to version [$PREV_VERSION]"
+      
+      # Create a backup of the file
+      cp CHANGELOG.md CHANGELOG.md.bak
+      
+      # Insert placeholder content after the version header
+      sed -i.tmp "s/## \[$PREV_VERSION\].*$/&\n\n### Changed\n- Automated version bump\n- This version was created during workflow testing/" CHANGELOG.md
+      
+      # Remove temporary file
+      rm -f CHANGELOG.md.tmp
+    fi
+  fi
+fi
+
+# Clean up
+rm "$TEMP_FILE"
+
+# Report results
+if [ ${#EMPTY_VERSIONS[@]} -eq 0 ]; then
+  echo "✅ No empty versions found in CHANGELOG.md"
+  exit 0
+else
+  echo ""
+  echo "Found ${#EMPTY_VERSIONS[@]} empty version(s) in CHANGELOG.md"
+  
+  if [ "$FIX_EMPTY" = true ]; then
+    echo "✅ Added placeholder content to all empty versions"
+    exit 0
+  else
+    echo "Run with --fix to automatically add placeholder content to empty versions:"
+    echo "./scripts/check-empty-versions.sh --fix"
+    exit 1
+  fi
+fi


### PR DESCRIPTION
This PR adds a complete solution to prevent and fix empty version sections in our CHANGELOG:

## New Features

1. **New utility script:** 
   - Detects empty version sections in CHANGELOG.md
   - Can automatically fix empty versions with  flag
   - Adds meaningful placeholders for testing/automation versions

2. **CI/CD integration:**
   - Enhanced  to detect empty versions during PR validation
   - Blocks PRs with empty versions in the changelog
   - Provides clear instructions for fixing issues

3. **Documentation:**
   - Updated versioning docs with information about empty versions
   - Added instructions for using the new validation tool
   - Fixed existing 0.5.5 version that was empty

## Motivation

This addresses our ongoing issue with empty version entries appearing in the CHANGELOG. While we already improved our versioning script to prevent creating new empty versions, this PR provides tools to:
1. Fix existing empty versions
2. Detect empty versions during CI/CD validation
3. Provide a consistent pattern for documenting automated version bumps

## Testing

Manual testing confirms:
- Script correctly identifies all empty versions
- Fix mode correctly adds placeholder content
- Integration with CI workflow prevents new empty versions