### PR TITLE
fix: enhance gitignore to fully exclude non-essential directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ node_modules/
 /docs/                 # All documentation files
 !docs/README.md       # Allow README files
 !docs/*/README.md     # Allow nested README files
+!docs/processes/safe-workflow-checklist.md  # Critical workflow document
+!docs/processes/git/git-workflow.md         # Essential git workflow guide
+!docs/processes/documentation/documentation-standards.md  # Documentation standards
+!docs/processes/feature-development-process.md  # Feature development guide
 
 # AI Documentation - Not suitable for public repository
 *CLAUDE*              # Claude AI-related files
@@ -32,6 +36,7 @@ CLAUDE.md             # Main Claude instructions file
 
 # Miscellaneous
 .DS_Store             # macOS folder attributes
+**/.DS_Store          # macOS folder attributes in subdirectories
 .env                  # Environment variables
 .env.*                # Environment variable variations
 .env.local
@@ -39,7 +44,9 @@ CLAUDE.md             # Main Claude instructions file
 .env.test.local
 .env.production.local
 temp/                 # Temporary files
+temp/**/*             # All files in temp directory
 _trash/               # Files pending removal
+_trash/**/*           # All files in trash directory
 *.backup              # Backup files
 *~                    # Temporary editor files
 *.swp                 # Vim swap files
@@ -49,6 +56,7 @@ uncommitted-*         # Files marked as not to be committed
 *secret*              # Files containing secrets
 *key*                 # Files containing keys
 .cache/               # Cache directories
+.releaserc.json       # Release configuration
 
 # Logs
 npm-debug.log*        # npm debug logs
@@ -57,6 +65,8 @@ yarn-error.log*       # Yarn error logs
 *.log                 # All log files
 test-results*.log     # Test result logs
 logs/                 # Logs directory
+logs/**/*             # All files in logs subdirectories
+!logs/test-results/README.md  # Keep test results README
 
 # Editor directories and files
 .idea/                # JetBrains IDE files
@@ -69,3 +79,7 @@ logs/                 # Logs directory
 
 # Wiki
 idle-game.wiki/       # Local wiki clone
+idle-game.wiki/**/*   # All files in wiki directory
+
+# Temporary files and backups
+package.json.orig     # Package file backup


### PR DESCRIPTION
## Summary
- Enhanced gitignore patterns to properly exclude trash, logs, temp and wiki directories
- Added nested patterns with **/* to catch all subdirectory content
- Added explicit rules for .DS_Store in all directories
- Added exceptions for critical process documentation
- Added rule for .releaserc.json and package.json.orig

## Test plan
- Verified git status no longer shows these directories
- Added additional patterns for thoroughness