### PR TITLE
fix: optimize CI workflow to skip tests for documentation-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,24 @@ name: CI
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/*.md'
+      - 'idle-game.wiki/**'
+      - 'CHANGELOG.md'
+      - 'DOCS_MANAGEMENT.md'
+      - 'CLAUDE.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/*.md'
+      - 'idle-game.wiki/**'
+      - 'CHANGELOG.md'
+      - 'DOCS_MANAGEMENT.md'
+      - 'CLAUDE.md'
   # Run weekly to ensure ongoing health checks
   schedule:
     - cron: '0 0 * * 0'  # Run at midnight every Sunday


### PR DESCRIPTION
## Summary
- Added paths-ignore configuration to the CI workflow
- Configured the workflow to skip build and test jobs for documentation PRs
- This will improve CI efficiency by not running unnecessary tests
- Included paths-ignore for markdown files, docs directory, and wiki

## Test plan
- Verified the CI workflow YAML syntax is correct
- The workflow will now only trigger on code changes, not documentation changes