### PR TITLE
fix: remove unnecessary files from tracking and enforce gitignore patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-*No unreleased changes at this time.*
+### Fixed
+- Properly enforce gitignore patterns by removing previously tracked files from the repository
+- Clean up project by removing temp, logs, and _trash directories from version control
+- Retain only essential files for directory structure (logs/test-results/README.md)
 
 ## [0.6.0] - 2025-02-27
 


### PR DESCRIPTION
## Summary
- Fixed issue with gitignore not properly excluding temp, logs, and _trash directories
- The gitignore file had correct patterns but files were already being tracked in git
- Removed all unnecessary files from git tracking while keeping them on filesystem
- Retained only essential files like logs/test-results/README.md for directory structure

## Test plan
- Verified that only essential files are tracked by git
- Confirmed that the gitignore patterns are now properly enforced
- Local files remain intact and unaffected

Resolves an issue where unwanted files were showing up in the repository despite having gitignore patterns in place.

🤖 Generated with Claude Code