### PR TITLE
fix: update integration tests with proper dependency injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Created helper functions to initialize managers with dependencies
   - Improved action creator mocking to avoid circular references
   - Added complete mock state for reliable test execution
+- Fixed integration tests by updating test structure for proper dependency injection
+  - Updated `gameCore.integration.test.tsx` to use proper BuildingManager initialization
+  - Updated `workers.integration.test.tsx` to use proper WorkerManager initialization 
+  - Rewrote `tasks.integration.test.ts` to use simpler mocking approach
+  - Fixed outdated import paths in integration tests
+  - Ensured manager singletons are properly reset between tests
 
 ### Added
 - New script to detect and fix empty versions in CHANGELOG


### PR DESCRIPTION
## Summary
- Fixed gameCore.integration.test.tsx to properly initialize BuildingManager with dependencies
- Fixed workers.integration.test.tsx to properly initialize WorkerManager with dependencies 
- Rewrote tasks.integration.test.ts to use simpler mocking approach
- Fixed outdated import paths in integration tests
- Ensured manager singletons are properly reset between tests
- Updated CHANGELOG with integration test fixes

## Test plan
All integration tests now pass with the refactored approach:
- gameCore.integration.test.tsx passes (4/4)
- workers.integration.test.tsx passes (1/1)
- tasks.integration.test.ts passes (12/12) 
- index.integration.test.tsx passes (2/2)

This completes the test fixes from the original issue #97.

## Testing pattern applied
All tests now follow the consistent pattern established in PR #100:
1. Use resetSingleton() instead of direct instance access
2. Create dependencies with proper type definitions
3. Initialize managers with full dependency injection
4. Provide complete mock state with all required properties
5. Reset mocks between tests to prevent interference

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>