### PR TITLE
docs: update CHANGELOG with test cleanup information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Updated `workers.integration.test.tsx` to use proper WorkerManager initialization 
   - Rewrote `tasks.integration.test.ts` to use simpler mocking approach
   - Fixed outdated import paths in integration tests
+- Cleaned up test suite by removing outdated tests and fixing App component tests
+  - Removed skipped tests in GameLoop test files that were testing outdated functionality
+  - Fixed App component tests by properly mocking the events state
+  - Improved test maintainability by removing obsolete test cases
   - Ensured manager singletons are properly reset between tests
 ### Added
 - New script to detect and fix empty versions in CHANGELOG


### PR DESCRIPTION
## Summary
- Add retroactive documentation for PR #102 to the CHANGELOG
- Document the test suite cleanup that was done:
  - Removal of outdated tests in GameLoop test files
  - Fixed App component tests with proper event state mocking
  - Improved overall test maintainability

## Context
The PR #102 successfully improved the test suite but didn't include CHANGELOG updates, which caused the PR check to fail. This PR addresses that by adding the appropriate documentation to the CHANGELOG.

🤖 Generated with [Claude Code](https://claude.ai/code)