### PR TITLE
fix: improve CHANGELOG versioning process with automated enforcement

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -2,7 +2,7 @@ name: PR Validation
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
     branches: [main]
 
 jobs:
@@ -40,6 +40,45 @@ jobs:
           
           echo "Validation passed: Branch name and PR title are correctly formatted"
   
+  check-version-labels:
+    name: Check Version Labels
+    runs-on: ubuntu-latest
+    if: github.base_ref == 'main'
+    
+    steps:
+      - name: Check for version labels
+        id: check-label
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const versionLabels = ['version:major', 'version:minor', 'version:patch', 'version:patch_level'];
+            const labels = context.payload.pull_request.labels.map(label => label.name);
+            const PR_TITLE = context.payload.pull_request.title;
+            
+            // Find if PR has any version label
+            const versionLabel = labels.find(label => versionLabels.includes(label));
+            
+            // Skip this check for specific PR types
+            if (PR_TITLE.match(/^(docs|chore|ci|test):/i)) {
+              console.log("PR type doesn't require version label, skipping check");
+              return;
+            }
+            
+            // For feat, fix, etc. PRs, enforce version label
+            if (!versionLabel) {
+              // Detect PR type to suggest appropriate version label
+              let suggestedLabel = 'version:patch';
+              if (PR_TITLE.startsWith('feat:')) {
+                suggestedLabel = 'version:minor';
+              } else if (PR_TITLE.includes('BREAKING CHANGE')) {
+                suggestedLabel = 'version:major';
+              }
+              
+              core.setFailed(`Missing version label on PR. Please add one of: version:major, version:minor, version:patch, version:patch_level. Based on your PR title, we recommend: ${suggestedLabel}`);
+            } else {
+              console.log(`✅ PR has version label: ${versionLabel}`);
+            }
+  
   check-changelog:
     name: Check CHANGELOG
     runs-on: ubuntu-latest
@@ -70,3 +109,16 @@ jobs:
           fi
           
           echo "CHANGELOG.md has been updated correctly"
+          
+      - name: Verify unreleased changes
+        run: |
+          # Skip this check for specific PR types
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          if echo "$PR_TITLE" | grep -E "^(docs|chore|ci|test):" > /dev/null; then
+            echo "PR type doesn't require validation of unreleased changes, skipping check"
+            exit 0
+          fi
+          
+          # Run the changelog verification script
+          chmod +x .github/workflows/scripts/check-changelog.sh
+          .github/workflows/scripts/check-changelog.sh --pr-mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Requirements to check each workflow step's logs for failures
   - Real-world case study of PR #115 that was improperly merged
   - Guidelines for detecting "hidden" failures in CI workflows
+- **Enhanced PR validation workflow** to properly enforce versioning:
+  - Added automatic version label checking for all feature/fix PRs
+  - Added suggestions for appropriate version labels based on PR title
+  - Smart detection of PR types to suggest correct version labels
+  - Improved CHANGELOG validation during PR review
+  - Clear validation messages and guidance for developers
 
 ### Fixed
 - Fixed linting errors in multiple files:
@@ -53,6 +59,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Updated best practices with detailed instructions on checking workflow logs
   - Added detailed instructions for verifying CHANGELOG updates
   - Documented actual process failure with PR #115 as a case study
+- **Fixed CHANGELOG versioning process**:
+  - Updated PR validation workflow to enforce version labels
+  - Enhanced check-changelog.sh script to provide better guidance
+  - Fixed workflow for CHANGELOG validation during PR reviews
+  - Enhanced documentation with clear examples and requirements
+  - Added explicit warnings about version label requirements in PR workflow
 
 ## [0.6.1] - 2025-02-28
 

--- a/docs/processes/pr-workflow.md
+++ b/docs/processes/pr-workflow.md
@@ -188,6 +188,11 @@ gh run view <run-id> --log-failed
 # - CHANGELOG updates for feature and fix PRs
 # - Documentation requirements
 # - Code coverage requirements
+# - VERSION LABELS - Every feature/fix PR MUST have a version label
+#   * version:major - For breaking changes
+#   * version:minor - For new features (feat:)
+#   * version:patch - For bug fixes (fix:)
+#   * version:patch_level - For minor tweaks
 
 # STEP 5: Check if any PRs that were merged just before yours have failing post-merge workflows
 # - This can indicate problems that might affect your PR
@@ -203,6 +208,10 @@ gh pr merge <pr-number> --squash --delete-branch
 **⚠️ MAJOR PROCESS FAILURE ALERT ⚠️**
 
 PR #115 was merged despite failing the CHANGELOG update check, leading to a broken process. This type of oversight compromises our quality control. You MUST verify EVERY check, not just the summary status.
+
+**⚠️ VERSION LABEL REQUIREMENT ⚠️**
+
+Every feature or fix PR MUST include a version label so auto-versioning can move changes from Unreleased to a proper version heading. Without the correct version label, the PR will be merged with unreleased changes still in the Unreleased section.
 
 ### 4. Explicitly Communicate Merge Status
 
@@ -354,19 +363,28 @@ npm start
    - Check logs for any failed steps
    - Verify all post-merge checks from recent PRs
    - Never assume success based on a green checkmark in GitHub UI
-2. **One Issue, One PR**: Each PR should address a single issue or feature
-3. **Small PRs**: Keep PRs small and focused for easier review and testing
-4. **Clear Commit Messages**: Use conventional commits (fix:, feat:, docs:, etc.)
-5. **Documentation First**: Document your changes as you make them
-6. **Test Early, Test Often**: Write tests before or alongside code changes
-7. **Self-Review**: Always review your own PR before requesting reviews
-8. **Keep CI Green**: Don't merge PRs that break the build or tests
-9. **Communicate**: Use PR comments to explain complex changes or decisions
-10. **Explicit Status Updates**: Always explicitly confirm successful merges to the user
-11. **Update Tests**: Always update tests when refactoring or changing behavior
-12. **Verify After Merge**: Always verify the main branch is stable after merging
-13. **Clear Communication**: Explicitly state when PRs are merged and branches are deleted
-14. **Appropriate Versioning**: Use the appropriate version level (major, minor, patch, or patch-level) to match the changes
-15. **Changelog Quality**: Keep changelog entries clear, concise, and properly categorized
+2. ⚠️ **ALWAYS ADD VERSION LABELS**: Every feature/fix PR must have a version label:
+   - `version:major` - For breaking changes
+   - `version:minor` - For new features (feat:)
+   - `version:patch` - For bug fixes (fix:)
+   - `version:patch_level` - For minor tweaks
+   - This is critical for the auto-versioning process to work properly
+3. ⚠️ **PROPER CHANGELOG MANAGEMENT**:
+   - During development: Add changes to the "Unreleased" section only
+   - Do not create version sections manually in PRs - auto-versioning will do this
+   - Ensure changelog entries are clear, concise, and properly categorized
+   - The auto-versioning process will move entries from "Unreleased" to proper version headings
+4. **One Issue, One PR**: Each PR should address a single issue or feature
+5. **Small PRs**: Keep PRs small and focused for easier review and testing
+6. **Clear Commit Messages**: Use conventional commits (fix:, feat:, docs:, etc.)
+7. **Documentation First**: Document your changes as you make them
+8. **Test Early, Test Often**: Write tests before or alongside code changes
+9. **Self-Review**: Always review your own PR before requesting reviews
+10. **Keep CI Green**: Don't merge PRs that break the build or tests
+11. **Communicate**: Use PR comments to explain complex changes or decisions
+12. **Explicit Status Updates**: Always explicitly confirm successful merges to the user
+13. **Update Tests**: Always update tests when refactoring or changing behavior
+14. **Verify After Merge**: Always verify the main branch is stable after merging
+15. **Clear Communication**: Explicitly state when PRs are merged and branches are deleted
 
 By following this workflow, we maintain a high-quality codebase with clear history and thorough documentation.

--- a/docs/processes/versioning-and-releases.md
+++ b/docs/processes/versioning-and-releases.md
@@ -26,6 +26,7 @@ This patch level extension allows us to make smaller incremental updates without
 3. **All changes MUST be categorized** under appropriate headings
 4. **Changes are for humans, not machines** - Write clear, understandable entries
 5. **Group similar types of changes together** - For better readability
+6. **⚠️ ALWAYS ADD VERSION LABELS TO PRs** - Without version labels, auto-versioning won't happen
 
 ### Adding Changes
 
@@ -54,6 +55,17 @@ Example:
 The versioning scripts enforce these requirements and will fail if:
 - You try to create a version with no changes
 - The Unreleased section is empty when versioning
+- PR is merged without a proper version label
+
+### Version Label Requirements
+
+Every PR that changes code (features, fixes) MUST have exactly one of these labels:
+- `version:major` - For breaking changes
+- `version:minor` - For new features (feat: PRs)
+- `version:patch` - For bug fixes (fix: PRs)
+- `version:patch_level` - For minor tweaks
+
+These labels tell the auto-versioning system what version number to create and tag when your PR is merged.
 
 ### Creating a Release
 


### PR DESCRIPTION
## Summary
This PR fixes the CHANGELOG versioning process to ensure proper versioning of changes.

## Problem
Our current process was allowing PRs to be merged without proper version labels, causing changes to remain in the Unreleased section indefinitely. This was identified when PR #115 was merged without properly moving changes from Unreleased to a version heading.

## Solution
1. Enhanced PR validation workflow:
   - Added automatic version label checking for all feature/fix PRs
   - Added intelligent version label suggestions based on PR title
   - Created better CHANGELOG validation during PR review

2. Improved check-changelog.sh script:
   - Added PR-specific validation mode with clear guidance
   - Enhanced warnings and recommendations for proper versioning
   - Better handling of unreleased changes during PR review

3. Updated documentation:
   - Enhanced PR workflow documentation with explicit version label requirements
   - Updated versioning and releases guide with critical requirements
   - Added explicit warnings about version labels in multiple places

## Testing
- Verified script modifications locally
- Updated CHANGELOG.md with an entry under Unreleased
- Verified documentation is clear and consistent

## Documentation
Added extensive documentation about the versioning process in:
- docs/processes/pr-workflow.md
- docs/processes/versioning-and-releases.md