### PR TITLE
fix: resolve YAML syntax issues in streamlined versioning workflow

### DIFF
--- a/.github/workflows/streamlined-versioning.yml
+++ b/.github/workflows/streamlined-versioning.yml
@@ -52,68 +52,50 @@ jobs:
         if: steps.version-bump.outputs.bump_type != 'none'
         run: |
           PR_BODY="${{ github.event.pull_request.body }}"
+          PR_TITLE="${{ github.event.pull_request.title }}"
           echo "Extracting changelog entry from PR description..."
           
-          # Create a temporary file with the PR body
-          echo "$PR_BODY" > pr_body.txt
-          
-          # More reliable extraction of changelog section
-          CHANGELOG_SECTION=""
-          CAPTURE=0
-          
-          while IFS= read -r line; do
-            if [[ "$line" == "## Changelog Entry" ]]; then
-              CAPTURE=1
-            elif [[ "$line" =~ ^## ]]; then
-              if [[ $CAPTURE -eq 1 ]]; then
-                CAPTURE=0
-              fi
-            elif [[ $CAPTURE -eq 1 ]]; then
-              if [[ -n "$CHANGELOG_SECTION" ]]; then
-                CHANGELOG_SECTION="$CHANGELOG_SECTION
-$line"
-              else
-                CHANGELOG_SECTION="$line"
-              fi
-            fi
-          done < pr_body.txt
-          
-          # Check if we found a changelog entry
-          if [ -z "$CHANGELOG_SECTION" ]; then
-            echo "No changelog entry found in PR description. Using PR title as fallback."
-            PR_TITLE="${{ github.event.pull_request.title }}"
-            TYPE=$(echo "$PR_TITLE" | sed -E 's/^(feat|fix|docs|chore|refactor|style|perf|test|build|ci|revert)(\!)?:.*/\1/')
-            DESCRIPTION=$(echo "$PR_TITLE" | sed -E 's/^(feat|fix|docs|chore|refactor|style|perf|test|build|ci|revert)(\!)?://' | sed -e 's/^[[:space:]]*//')
+          # Simplest possible extraction approach - look for fixed patterns
+          if [[ "$PR_BODY" == *"## Changelog Entry"* && "$PR_BODY" == *"### "* ]]; then
+            # PR has a changelog entry section with subsections
+            echo "Found changelog entry in PR description."
             
-            case "$TYPE" in
-              feat)
-                CHANGELOG_ENTRY="### Added
-- $DESCRIPTION"
-                ;;
-              fix)
-                CHANGELOG_ENTRY="### Fixed
-- $DESCRIPTION"
-                ;;
-              refactor|perf)
-                CHANGELOG_ENTRY="### Changed
-- $DESCRIPTION"
-                ;;
-              docs|chore|style|test|build|ci|revert)
-                CHANGELOG_ENTRY="### Changed
-- $DESCRIPTION"
-                ;;
-              *)
-                CHANGELOG_ENTRY="### Changed
-- $DESCRIPTION"
-                ;;
-            esac
+            # Extract from after "## Changelog Entry" to either the next heading or end of string
+            CHANGELOG_TEXT=$(echo "$PR_BODY" | sed -n '/## Changelog Entry/,/## /p' | grep -v "^## Changelog Entry" | grep -v "^## ")
+            
+            # If we didn't match anything, try getting everything after changelog entry
+            if [ -z "$CHANGELOG_TEXT" ]; then
+              CHANGELOG_TEXT=$(echo "$PR_BODY" | sed -n '/## Changelog Entry/,$p' | grep -v "^## Changelog Entry")
+            fi
+            
+            # Save the changelog entry (trimmed)
+            CHANGELOG_ENTRY=$(echo "$CHANGELOG_TEXT" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
           else
-            CHANGELOG_ENTRY="$CHANGELOG_SECTION"
+            # Fallback to using PR title to generate a changelog entry
+            echo "No changelog entry found in PR description. Using PR title as fallback."
+            
+            # Extract type and description from PR title
+            if [[ "$PR_TITLE" =~ ^feat: ]]; then
+              TYPE="feat"
+              DESCRIPTION=$(echo "$PR_TITLE" | sed 's/^feat: //')
+              CHANGELOG_ENTRY="### Added
+- $DESCRIPTION"
+            elif [[ "$PR_TITLE" =~ ^fix: ]]; then
+              TYPE="fix"
+              DESCRIPTION=$(echo "$PR_TITLE" | sed 's/^fix: //')
+              CHANGELOG_ENTRY="### Fixed
+- $DESCRIPTION"
+            else
+              # Default to "Changed" for any other type
+              DESCRIPTION=$(echo "$PR_TITLE" | sed 's/^[^:]*: //')
+              CHANGELOG_ENTRY="### Changed
+- $DESCRIPTION"
+            fi
           fi
           
           # Save to file for later use
           echo "$CHANGELOG_ENTRY" > changelog_entry.txt
-          echo "Changelog entry:"
+          echo "Changelog entry extracted:"
           cat changelog_entry.txt
           
       - name: Bump version
@@ -169,41 +151,31 @@ $line"
             exit 1
           fi
           
-          # Load the changelog entry from the file
+          # Get the changelog entry from our file
           CHANGELOG_ENTRY=$(cat changelog_entry.txt)
           
-          # Create a new changelog with our updates
+          # Simple string-based search and replace approach
+          # 1. Replace Unreleased section with new content
+          sed -i 's/## \[Unreleased\]/## [Unreleased]\n\n*No unreleased changes at this time.*\n\n## ['"$NEW_VERSION"'] - '"$DATE"'/' CHANGELOG.md
+          
+          # 2. Insert changelog entry after the newly created version header
+          awk -v ver="## [$NEW_VERSION] - $DATE" -v entry="$CHANGELOG_ENTRY" '
           {
-            # Find the start of the file until the Unreleased section
-            sed -n '1,/## \[Unreleased\]/p' CHANGELOG.md
-            
-            # Add empty line after Unreleased header
-            echo ""
-            
-            # Add placeholder for unreleased
-            echo "*No unreleased changes at this time.*"
-            echo ""
-            
-            # Add new version with date
-            echo "## [$NEW_VERSION] - $DATE"
-            echo ""
-            
-            # Add changelog entry
-            echo "$CHANGELOG_ENTRY"
-            echo ""
-            
-            # Add the rest of the file starting from the next version
-            sed -n '/## \[[0-9]/,$p' CHANGELOG.md
-          } > new_changelog.md
+            print $0
+            if ($0 ~ ver) {
+              print ""
+              print entry
+            }
+          }' CHANGELOG.md > temp_changelog.md
           
-          # Replace old changelog with new one
-          mv new_changelog.md CHANGELOG.md
+          # 3. Replace the original file
+          cp temp_changelog.md CHANGELOG.md
+          rm temp_changelog.md
           
-          # Update package.json to ensure it has the right version
+          # Update package.json with the new version
           node -e "const fs = require('fs'); const pkg = JSON.parse(fs.readFileSync('package.json')); pkg.version = '$NEW_VERSION'; fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');"
           
           echo "CHANGELOG.md and package.json updated successfully"
-          echo "Added version $NEW_VERSION with changelog entry"
           
       - name: Commit and push changes
         if: steps.version-bump.outputs.bump_type != 'none'

--- a/.github/workflows/streamlined-versioning.yml
+++ b/.github/workflows/streamlined-versioning.yml
@@ -51,52 +51,63 @@ jobs:
         id: changelog
         if: steps.version-bump.outputs.bump_type != 'none'
         run: |
-          PR_BODY="${{ github.event.pull_request.body }}"
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          echo "Extracting changelog entry from PR description..."
+          # Save PR body to a file to work with it safely
+          echo '${{ github.event.pull_request.body }}' > pr_body.txt
           
-          # Simplest possible extraction approach - look for fixed patterns
-          if [[ "$PR_BODY" == *"## Changelog Entry"* && "$PR_BODY" == *"### "* ]]; then
-            # PR has a changelog entry section with subsections
-            echo "Found changelog entry in PR description."
+          # Create a script to process the PR body and extract changelog
+          cat > extract_changelog.sh << 'EOF'
+          #!/bin/bash
+          PR_BODY=$(cat pr_body.txt)
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          
+          # Check if PR body contains changelog entry section
+          if grep -q "## Changelog Entry" pr_body.txt; then
+            echo "Found changelog entry section"
+            # Use a temporary file approach to extract content
+            sed -n '/## Changelog Entry/,/^## /p' pr_body.txt | grep -v "^## Changelog Entry" | grep -v "^## " > changelog_content.txt
             
-            # Extract from after "## Changelog Entry" to either the next heading or end of string
-            CHANGELOG_TEXT=$(echo "$PR_BODY" | sed -n '/## Changelog Entry/,/## /p' | grep -v "^## Changelog Entry" | grep -v "^## ")
-            
-            # If we didn't match anything, try getting everything after changelog entry
-            if [ -z "$CHANGELOG_TEXT" ]; then
-              CHANGELOG_TEXT=$(echo "$PR_BODY" | sed -n '/## Changelog Entry/,$p' | grep -v "^## Changelog Entry")
+            # If nothing was extracted (e.g., changelog at end of PR), get everything after the header
+            if [ ! -s changelog_content.txt ]; then
+              sed -n '/## Changelog Entry/,$p' pr_body.txt | grep -v "^## Changelog Entry" > changelog_content.txt
             fi
             
-            # Save the changelog entry (trimmed)
-            CHANGELOG_ENTRY=$(echo "$CHANGELOG_TEXT" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-          else
-            # Fallback to using PR title to generate a changelog entry
-            echo "No changelog entry found in PR description. Using PR title as fallback."
-            
-            # Extract type and description from PR title
-            if [[ "$PR_TITLE" =~ ^feat: ]]; then
-              TYPE="feat"
-              DESCRIPTION=$(echo "$PR_TITLE" | sed 's/^feat: //')
-              CHANGELOG_ENTRY="### Added
-- $DESCRIPTION"
-            elif [[ "$PR_TITLE" =~ ^fix: ]]; then
-              TYPE="fix"
-              DESCRIPTION=$(echo "$PR_TITLE" | sed 's/^fix: //')
-              CHANGELOG_ENTRY="### Fixed
-- $DESCRIPTION"
+            # Check if we got changelog content with any of the expected headers
+            if grep -q "### " changelog_content.txt; then
+              echo "Using changelog entry from PR description"
+              cat changelog_content.txt > changelog_entry.txt
             else
-              # Default to "Changed" for any other type
+              echo "Changelog section found but no content - fallback to PR title"
+              GOTO_FALLBACK=1
+            fi
+          else
+            echo "No changelog section found - fallback to PR title"
+            GOTO_FALLBACK=1
+          fi
+          
+          # Fallback to PR title if needed
+          if [ "${GOTO_FALLBACK:-0}" == "1" ]; then
+            if [[ "$PR_TITLE" =~ ^feat: ]]; then
+              DESCRIPTION=$(echo "$PR_TITLE" | sed 's/^feat: //')
+              echo "### Added" > changelog_entry.txt
+              echo "- $DESCRIPTION" >> changelog_entry.txt
+            elif [[ "$PR_TITLE" =~ ^fix: ]]; then
+              DESCRIPTION=$(echo "$PR_TITLE" | sed 's/^fix: //')
+              echo "### Fixed" > changelog_entry.txt
+              echo "- $DESCRIPTION" >> changelog_entry.txt
+            else
               DESCRIPTION=$(echo "$PR_TITLE" | sed 's/^[^:]*: //')
-              CHANGELOG_ENTRY="### Changed
-- $DESCRIPTION"
+              echo "### Changed" > changelog_entry.txt
+              echo "- $DESCRIPTION" >> changelog_entry.txt
             fi
           fi
           
-          # Save to file for later use
-          echo "$CHANGELOG_ENTRY" > changelog_entry.txt
-          echo "Changelog entry extracted:"
+          echo "Extracted changelog entry:"
           cat changelog_entry.txt
+          EOF
+          
+          # Make script executable and run it
+          chmod +x extract_changelog.sh
+          ./extract_changelog.sh
           
       - name: Bump version
         if: steps.version-bump.outputs.bump_type != 'none'
@@ -145,34 +156,49 @@ jobs:
           git checkout main
           git pull origin main
           
+          # Create a script to update the changelog safely
+          cat > update_changelog.sh << 'EOF'
+          #!/bin/bash
+          NEW_VERSION="${{ steps.bump-version.outputs.new_version }}"
+          DATE=$(date +%Y-%m-%d)
+          
           # Check if Unreleased section exists
           if ! grep -q "## \[Unreleased\]" CHANGELOG.md; then
             echo "Error: CHANGELOG.md does not have an [Unreleased] section"
             exit 1
           fi
           
-          # Get the changelog entry from our file
-          CHANGELOG_ENTRY=$(cat changelog_entry.txt)
+          # Create new changelog content
+          (
+            # Get everything up to and including the Unreleased header
+            sed -n '1,/## \[Unreleased\]/p' CHANGELOG.md
+            
+            # Add placeholder for Unreleased
+            echo
+            echo "*No unreleased changes at this time.*"
+            echo
+            
+            # Add the new version header
+            echo "## [$NEW_VERSION] - $DATE"
+            echo
+            
+            # Add the changelog entry
+            cat changelog_entry.txt
+            echo
+            
+            # Get the rest of the file (everything after Unreleased)
+            sed -n '/## \[Unreleased\]/,$ p' CHANGELOG.md | tail -n +2
+          ) > CHANGELOG.md.new
           
-          # Simple string-based search and replace approach
-          # 1. Replace Unreleased section with new content
-          sed -i 's/## \[Unreleased\]/## [Unreleased]\n\n*No unreleased changes at this time.*\n\n## ['"$NEW_VERSION"'] - '"$DATE"'/' CHANGELOG.md
+          # Replace original with new version
+          mv CHANGELOG.md.new CHANGELOG.md
+          EOF
           
-          # 2. Insert changelog entry after the newly created version header
-          awk -v ver="## [$NEW_VERSION] - $DATE" -v entry="$CHANGELOG_ENTRY" '
-          {
-            print $0
-            if ($0 ~ ver) {
-              print ""
-              print entry
-            }
-          }' CHANGELOG.md > temp_changelog.md
+          # Make the script executable and run it
+          chmod +x update_changelog.sh
+          ./update_changelog.sh
           
-          # 3. Replace the original file
-          cp temp_changelog.md CHANGELOG.md
-          rm temp_changelog.md
-          
-          # Update package.json with the new version
+          # Update package.json with new version (again to be safe)
           node -e "const fs = require('fs'); const pkg = JSON.parse(fs.readFileSync('package.json')); pkg.version = '$NEW_VERSION'; fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');"
           
           echo "CHANGELOG.md and package.json updated successfully"

--- a/.github/workflows/streamlined-versioning.yml
+++ b/.github/workflows/streamlined-versioning.yml
@@ -54,11 +54,30 @@ jobs:
           PR_BODY="${{ github.event.pull_request.body }}"
           echo "Extracting changelog entry from PR description..."
           
-          # More robust extraction of content between "## Changelog Entry" and the next heading or end of file
-          # This preserves empty lines within the section which are important for formatting
-          CHANGELOG_SECTION=$(echo "$PR_BODY" | awk '/## Changelog Entry/{flag=1;next} /^## /{flag=0} flag')
+          # Create a temporary file with the PR body to avoid shell interpretation issues
+          echo "$PR_BODY" > pr_body.txt
           
-          # Remove any leading/trailing whitespace but preserve internal formatting
+          # Safer extraction of changelog section without relying on shell interpretation
+          CHANGELOG_SECTION=""
+          CAPTURE=0
+          
+          while IFS= read -r line; do
+            if [[ "$line" == "## Changelog Entry" ]]; then
+              CAPTURE=1
+              continue
+            elif [[ "$line" =~ ^## ]]; then
+              if [[ $CAPTURE -eq 1 ]]; then
+                CAPTURE=0
+              fi
+            fi
+            
+            if [[ $CAPTURE -eq 1 ]]; then
+              CHANGELOG_SECTION="${CHANGELOG_SECTION}${line}
+"
+            fi
+          done < pr_body.txt
+          
+          # Remove leading/trailing whitespace
           CHANGELOG_ENTRY=$(echo "$CHANGELOG_SECTION" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
           
           if [ -z "$CHANGELOG_ENTRY" ]; then
@@ -69,25 +88,30 @@ jobs:
             
             case "$TYPE" in
               feat)
-                CHANGELOG_ENTRY="### Added\n- $DESCRIPTION"
+                CHANGELOG_ENTRY="### Added
+- $DESCRIPTION"
                 ;;
               fix)
-                CHANGELOG_ENTRY="### Fixed\n- $DESCRIPTION"
+                CHANGELOG_ENTRY="### Fixed
+- $DESCRIPTION"
                 ;;
               refactor|perf)
-                CHANGELOG_ENTRY="### Changed\n- $DESCRIPTION"
+                CHANGELOG_ENTRY="### Changed
+- $DESCRIPTION"
                 ;;
               docs|chore|style|test|build|ci|revert)
-                CHANGELOG_ENTRY="### Changed\n- $DESCRIPTION"
+                CHANGELOG_ENTRY="### Changed
+- $DESCRIPTION"
                 ;;
               *)
-                CHANGELOG_ENTRY="### Changed\n- $DESCRIPTION"
+                CHANGELOG_ENTRY="### Changed
+- $DESCRIPTION"
                 ;;
             esac
           fi
           
-          # Save to file for later use
-          echo -e "$CHANGELOG_ENTRY" > changelog_entry.txt
+          # Save to file for later use - avoid using echo -e which can cause issues
+          echo "$CHANGELOG_ENTRY" > changelog_entry.txt
           echo "Changelog entry:"
           cat changelog_entry.txt
           
@@ -144,45 +168,40 @@ jobs:
             exit 1
           fi
           
-          # Read the changelog entry and ensure it doesn't have any shell special characters issues
+          # Load the changelog entry from the file
           CHANGELOG_ENTRY=$(cat changelog_entry.txt)
           
-          # Make a backup of the original CHANGELOG.md
-          cp CHANGELOG.md CHANGELOG.md.bak
+          # Create a temporary file for building the new changelog
+          touch new_changelog.md
           
-          # Create new version section in CHANGELOG - keep the Unreleased section empty
-          sed -i "s/## \[Unreleased\]/## [Unreleased]\n\n*No unreleased changes at this time.*\n\n## [$NEW_VERSION] - $DATE/" CHANGELOG.md
+          # Process CHANGELOG.md line by line to insert new version safely
+          FOUND_UNRELEASED=0
+          while IFS= read -r line; do
+            # Add line to new changelog
+            echo "$line" >> new_changelog.md
+            
+            # If this is the Unreleased section heading, add unreleased placeholder and new version
+            if [[ "$line" == "## [Unreleased]" ]]; then
+              FOUND_UNRELEASED=1
+              echo "" >> new_changelog.md
+              echo "*No unreleased changes at this time.*" >> new_changelog.md
+              echo "" >> new_changelog.md
+              echo "## [$NEW_VERSION] - $DATE" >> new_changelog.md
+              echo "" >> new_changelog.md
+              # Add the changelog entry
+              echo "$CHANGELOG_ENTRY" >> new_changelog.md
+              echo "" >> new_changelog.md
+            fi
+          done < CHANGELOG.md
           
-          # Read the entire file content
-          CHANGELOG_CONTENT=$(cat CHANGELOG.md)
+          # Replace the original with our new version
+          mv new_changelog.md CHANGELOG.md
           
-          # Replace the placeholder text with the actual changelog entry
-          # This approach avoids issues with special characters in the changelog entry
-          # First remove the placeholder text
-          TEMP_CONTENT=$(echo "$CHANGELOG_CONTENT" | sed "/## \[$NEW_VERSION\] - $DATE/,/^$/s/*No unreleased changes at this time.*//")
-          
-          # Then add the actual changelog entry after the version heading
-          echo "$TEMP_CONTENT" > changelog_temp.md
-          UPDATED_CONTENT=$(awk -v ver="## [$NEW_VERSION] - $DATE" -v entry="$CHANGELOG_ENTRY" '{
-              print $0;
-              if ($0 ~ ver) {
-                print "";
-                print entry;
-              }
-            }' changelog_temp.md)
-          
-          # Write the updated content back to the file
-          echo "$UPDATED_CONTENT" > CHANGELOG.md
-          
-          # Fix any potential blank lines that might have been introduced
-          sed -i '/^[[:space:]]*$/d' CHANGELOG.md
-          # Ensure there's a newline between sections
-          sed -i "s/## \[/\n## \[/g" CHANGELOG.md
-          
-          # Update package.json again to ensure it has the right version
+          # Update package.json to ensure it has the right version
           node -e "const fs = require('fs'); const pkg = JSON.parse(fs.readFileSync('package.json')); pkg.version = '$NEW_VERSION'; fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');"
           
           echo "CHANGELOG.md and package.json updated successfully"
+          echo "Added version $NEW_VERSION with changelog entry"
           echo "Changelog entry:"
           echo "$CHANGELOG_ENTRY"
           

--- a/.github/workflows/streamlined-versioning.yml
+++ b/.github/workflows/streamlined-versioning.yml
@@ -54,33 +54,32 @@ jobs:
           PR_BODY="${{ github.event.pull_request.body }}"
           echo "Extracting changelog entry from PR description..."
           
-          # Create a temporary file with the PR body to avoid shell interpretation issues
+          # Create a temporary file with the PR body
           echo "$PR_BODY" > pr_body.txt
           
-          # Safer extraction of changelog section without relying on shell interpretation
+          # More reliable extraction of changelog section
           CHANGELOG_SECTION=""
           CAPTURE=0
           
           while IFS= read -r line; do
             if [[ "$line" == "## Changelog Entry" ]]; then
               CAPTURE=1
-              continue
             elif [[ "$line" =~ ^## ]]; then
               if [[ $CAPTURE -eq 1 ]]; then
                 CAPTURE=0
               fi
-            fi
-            
-            if [[ $CAPTURE -eq 1 ]]; then
-              CHANGELOG_SECTION="${CHANGELOG_SECTION}${line}
-"
+            elif [[ $CAPTURE -eq 1 ]]; then
+              if [[ -n "$CHANGELOG_SECTION" ]]; then
+                CHANGELOG_SECTION="$CHANGELOG_SECTION
+$line"
+              else
+                CHANGELOG_SECTION="$line"
+              fi
             fi
           done < pr_body.txt
           
-          # Remove leading/trailing whitespace
-          CHANGELOG_ENTRY=$(echo "$CHANGELOG_SECTION" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-          
-          if [ -z "$CHANGELOG_ENTRY" ]; then
+          # Check if we found a changelog entry
+          if [ -z "$CHANGELOG_SECTION" ]; then
             echo "No changelog entry found in PR description. Using PR title as fallback."
             PR_TITLE="${{ github.event.pull_request.title }}"
             TYPE=$(echo "$PR_TITLE" | sed -E 's/^(feat|fix|docs|chore|refactor|style|perf|test|build|ci|revert)(\!)?:.*/\1/')
@@ -108,9 +107,11 @@ jobs:
 - $DESCRIPTION"
                 ;;
             esac
+          else
+            CHANGELOG_ENTRY="$CHANGELOG_SECTION"
           fi
           
-          # Save to file for later use - avoid using echo -e which can cause issues
+          # Save to file for later use
           echo "$CHANGELOG_ENTRY" > changelog_entry.txt
           echo "Changelog entry:"
           cat changelog_entry.txt
@@ -171,30 +172,31 @@ jobs:
           # Load the changelog entry from the file
           CHANGELOG_ENTRY=$(cat changelog_entry.txt)
           
-          # Create a temporary file for building the new changelog
-          touch new_changelog.md
-          
-          # Process CHANGELOG.md line by line to insert new version safely
-          FOUND_UNRELEASED=0
-          while IFS= read -r line; do
-            # Add line to new changelog
-            echo "$line" >> new_changelog.md
+          # Create a new changelog with our updates
+          {
+            # Find the start of the file until the Unreleased section
+            sed -n '1,/## \[Unreleased\]/p' CHANGELOG.md
             
-            # If this is the Unreleased section heading, add unreleased placeholder and new version
-            if [[ "$line" == "## [Unreleased]" ]]; then
-              FOUND_UNRELEASED=1
-              echo "" >> new_changelog.md
-              echo "*No unreleased changes at this time.*" >> new_changelog.md
-              echo "" >> new_changelog.md
-              echo "## [$NEW_VERSION] - $DATE" >> new_changelog.md
-              echo "" >> new_changelog.md
-              # Add the changelog entry
-              echo "$CHANGELOG_ENTRY" >> new_changelog.md
-              echo "" >> new_changelog.md
-            fi
-          done < CHANGELOG.md
+            # Add empty line after Unreleased header
+            echo ""
+            
+            # Add placeholder for unreleased
+            echo "*No unreleased changes at this time.*"
+            echo ""
+            
+            # Add new version with date
+            echo "## [$NEW_VERSION] - $DATE"
+            echo ""
+            
+            # Add changelog entry
+            echo "$CHANGELOG_ENTRY"
+            echo ""
+            
+            # Add the rest of the file starting from the next version
+            sed -n '/## \[[0-9]/,$p' CHANGELOG.md
+          } > new_changelog.md
           
-          # Replace the original with our new version
+          # Replace old changelog with new one
           mv new_changelog.md CHANGELOG.md
           
           # Update package.json to ensure it has the right version
@@ -202,8 +204,6 @@ jobs:
           
           echo "CHANGELOG.md and package.json updated successfully"
           echo "Added version $NEW_VERSION with changelog entry"
-          echo "Changelog entry:"
-          echo "$CHANGELOG_ENTRY"
           
       - name: Commit and push changes
         if: steps.version-bump.outputs.bump_type != 'none'


### PR DESCRIPTION
This PR fixes the YAML syntax issues in the streamlined versioning workflow.

## Problem
Previous approaches had recurring YAML syntax errors with multiline strings and shell variable handling in the workflow file, causing failures in extracting changelog entries and updating the CHANGELOG.md file.

## Solution
- Moved complex script logic into separate shell scripts created at runtime
- Used temporary files instead of problematic multiline shell variables
- Simplified the changelog extraction process to avoid YAML parsing issues
- Used heredocs with single quotes to prevent YAML interpretation problems

## Type of Change
- [x] Bug fix (fix: ...)

## Changelog Entry

### Fixed
- Resolved YAML syntax issues in the streamlined versioning workflow
- Fixed changelog extraction reliability with a more robust approach
- Improved the CHANGELOG.md update process by using isolated scripts