### PR TITLE
fix: add error handling to changelog extraction script

### DIFF
--- a/.github/workflows/streamlined-versioning.yml
+++ b/.github/workflows/streamlined-versioning.yml
@@ -63,7 +63,7 @@ jobs:
           # Ultra simple extraction strategy:
           # Get the first non-empty line after the PR title line
           # Skip heading lines, empty lines, and warning text
-          CHANGELOG_ENTRY=$(grep -v "^#" pr_body.txt | grep -v "^$" | grep -v "⚠️" | head -n 1)
+          CHANGELOG_ENTRY=$(grep -v "^#" pr_body.txt | grep -v "^$" | grep -v "⚠️" | head -n 1 || echo "")
           
           if [ -n "$CHANGELOG_ENTRY" ]; then
             echo "Found changelog entry: $CHANGELOG_ENTRY"


### PR DESCRIPTION
Fixed the error in the extraction script by adding fallback to empty string

When no lines match our filtering criteria, the grep | head pipeline can exit with non-zero status, causing the script to fail. This PR adds a fallback to an empty string to handle this case gracefully.

## What was fixed
- Added `|| echo ""` to ensure the script doesn't fail when no matching lines are found
- Prevents the "/home/runner/work/_temp/...sh: line 13: -: command not found" error
- Makes the script more robust by handling edge cases better
